### PR TITLE
Collapse IN (?, ?, ?) clauses to IN (...)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: go
 dist: trusty
 
 go:
-    - 1.6
+    - "1.10"
 
 script: go test github.com/honeycombio/mysqltools/...

--- a/query/normalizer/parser_test.go
+++ b/query/normalizer/parser_test.go
@@ -127,6 +127,14 @@ var parserTests = []struct {
 		[]string{},
 		[]string{},
 	},
+
+	{"IN clauses normalized",
+		"SELECT `colname` FROM `tablename` WHERE id IN (1, 2, 3, 4, 5)",
+		"select `colname` from `tablename` where id in (...)",
+		"select",
+		[]string{"tablename"},
+		[]string{},
+	},
 	//{"alter table", "ALTER TABLE `tablename` ADD COLUMN `text` VARCHAR(100) NOT NULL AFTER `before_text`", "alter table tablename add column text varchar(?) not null after before_text"},
 }
 


### PR DESCRIPTION
Various people have complained that the queries

```
SELECT * FROM sometable WHERE id IN (?, ?)
SELECT * FROM sometable WHERE id IN (?, ?, ?)
...
```

are all normalized differently. Fix this by normalizing `IN` clauses to

```
SELECT * FROM sometable WHERE id IN (...)
```

instead.